### PR TITLE
feat: configurable maximum file size via range slider in options

### DIFF
--- a/src/content-script/extension.test.ts
+++ b/src/content-script/extension.test.ts
@@ -59,6 +59,11 @@ describe('runExtension', () => {
       content: 'X'.repeat(LIMIT + 10),
     });
 
+    wrapMock(getSettings).mockResolvedValue({
+      buttons: { query: true, formatted: true, raw: true, download: true },
+      downloadMode: 'dropdown',
+      maxFileSize: 3,
+    });
     wrapMock(findNodeWithCode).mockResolvedValue(preNode);
     wrapMock(sendMessage).mockResolvedValue(tNull());
     wrapMock(format).mockResolvedValue('formatted');
@@ -78,6 +83,11 @@ describe('runExtension', () => {
       content: 'X'.repeat(LIMIT + 10),
     });
 
+    wrapMock(getSettings).mockResolvedValue({
+      buttons: { query: true, formatted: true, raw: true, download: true },
+      downloadMode: 'dropdown',
+      maxFileSize: 3,
+    });
     wrapMock(findNodeWithCode).mockResolvedValue(preNode);
     wrapMock(format).mockResolvedValue({ type: 'error', scope: 'worker', error: 'Invalid JSON' });
 
@@ -95,6 +105,11 @@ describe('runExtension', () => {
       content: 'X'.repeat(LIMIT + 10),
     });
 
+    wrapMock(getSettings).mockResolvedValue({
+      buttons: { query: true, formatted: true, raw: true, download: true },
+      downloadMode: 'dropdown',
+      maxFileSize: 3,
+    });
     const consoleSpy = rstest.spyOn(console, 'error').mockImplementation(() => undefined);
     wrapMock(findNodeWithCode).mockResolvedValue(preNode);
     wrapMock(format).mockRejectedValue({ type: 'error', scope: 'worker', error: 'Invalid JSON' });

--- a/src/content-script/extension.test.ts
+++ b/src/content-script/extension.test.ts
@@ -3,12 +3,13 @@ import '@testing/browser.mock';
 import '@testing/background.mock';
 import '@testing/settings.mock';
 import { download, format, jq, pushHistory, tokenize } from '@core/background';
+import { getSettings } from '@core/settings';
 import { sendMessage } from '@core/browser';
 import { createElement } from '@core/dom';
 import { registerStyle } from '@core/ui/helpers';
 import { tNull, tObject, tProperty, tString } from '@testing/json';
 import { wrapMock } from '@testing/helpers';
-import { LIMIT, runExtension } from './extension';
+import { LIMIT, ONE_MEGABYTE_LENGTH, runExtension } from './extension';
 import { ToolboxElement } from './ui/toolbox/toolbox';
 import { findNodeWithCode } from './json-detector';
 import type { ContainerElement } from './ui/container/container';
@@ -103,6 +104,28 @@ describe('runExtension', () => {
     expect(format).toHaveBeenCalled();
     expect(consoleSpy).toHaveBeenCalled();
     expect(tokenize).not.toHaveBeenCalled();
+  });
+
+  test('when content is within a custom maxFileSize setting, tokenizes normally', async () => {
+    wrapMock(getSettings).mockResolvedValue({
+      buttons: { query: true, formatted: true, raw: true, download: true },
+      downloadMode: 'dropdown',
+      maxFileSize: 5,
+    });
+
+    const preNode = createElement({
+      element: 'pre',
+      // 4 MB — above default 3 MB limit but below the custom 5 MB limit
+      content: 'X'.repeat(ONE_MEGABYTE_LENGTH * 4),
+    });
+
+    wrapMock(findNodeWithCode).mockResolvedValue(preNode);
+    wrapMock(tokenize).mockResolvedValue(tObject(tProperty('key', tString('value'))));
+
+    await runExtension();
+
+    expect(tokenize).toHaveBeenCalled();
+    expect(format).not.toHaveBeenCalled();
   });
 
   test('when content is base', async () => {

--- a/src/content-script/extension.ts
+++ b/src/content-script/extension.ts
@@ -39,7 +39,10 @@ export const runExtension = async () => {
 
   shadowRoot.appendChild(container);
 
-  if (content.length > LIMIT) {
+  const settings = await getSettings();
+  const limit = settings.maxFileSize * ONE_MEGABYTE_LENGTH;
+
+  if (content.length > limit) {
     preNode.remove();
 
     try {
@@ -63,7 +66,7 @@ export const runExtension = async () => {
 
     container.message(
       'File is too large',
-      'File is too large to be processed (More than 3MB). It has been formatted instead.',
+      `File is too large to be processed (More than ${settings.maxFileSize}MB). It has been formatted instead.`,
     );
 
     return;
@@ -79,8 +82,6 @@ export const runExtension = async () => {
       container.stopLoading();
     }
   };
-
-  const settings = await getSettings();
 
   setTimeout(() => {
     const toolbox = document.createElement('mjf-toolbox');

--- a/src/core/settings/index.test.ts
+++ b/src/core/settings/index.test.ts
@@ -96,6 +96,7 @@ describe('settings', () => {
       const settings = {
         buttons: { query: false, formatted: true, raw: true, download: false },
         downloadMode: 'formatted' as const,
+        maxFileSize: 5,
       };
 
       await saveSettings(settings);

--- a/src/core/settings/index.test.ts
+++ b/src/core/settings/index.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, rstest, test } from '@rstest/core';
-import { DEFAULT_SETTINGS, getSettings, saveSettings } from './index';
+import { DEFAULT_MAX_FILE_SIZE_MB, DEFAULT_SETTINGS, getSettings, saveSettings } from './index';
 
 const STORAGE_KEY = 'mjf_settings';
 
@@ -42,6 +42,10 @@ describe('settings', () => {
 
     test('has downloadMode set to dropdown', () => {
       expect(DEFAULT_SETTINGS.downloadMode).toBe('dropdown');
+    });
+
+    test('has maxFileSize set to DEFAULT_MAX_FILE_SIZE_MB', () => {
+      expect(DEFAULT_SETTINGS.maxFileSize).toBe(DEFAULT_MAX_FILE_SIZE_MB);
     });
   });
 

--- a/src/core/settings/index.ts
+++ b/src/core/settings/index.ts
@@ -10,7 +10,12 @@ export interface ToolbarButtonsSettings {
 export interface ExtensionSettings {
   buttons: ToolbarButtonsSettings;
   downloadMode: DownloadMode;
+  maxFileSize: number;
 }
+
+export const MIN_FILE_SIZE_MB = 1;
+export const MAX_FILE_SIZE_MB = 20;
+export const DEFAULT_MAX_FILE_SIZE_MB = 3;
 
 export const DEFAULT_SETTINGS: ExtensionSettings = {
   buttons: {
@@ -20,6 +25,7 @@ export const DEFAULT_SETTINGS: ExtensionSettings = {
     download: true,
   },
   downloadMode: 'dropdown',
+  maxFileSize: DEFAULT_MAX_FILE_SIZE_MB,
 };
 
 const STORAGE_KEY = 'mjf_settings';

--- a/src/core/settings/index.ts
+++ b/src/core/settings/index.ts
@@ -15,7 +15,7 @@ export interface ExtensionSettings {
 
 export const MIN_FILE_SIZE_MB = 1;
 export const MAX_FILE_SIZE_MB = 150;
-export const DEFAULT_MAX_FILE_SIZE_MB = 5;
+export const DEFAULT_MAX_FILE_SIZE_MB = 10;
 
 export const DEFAULT_SETTINGS: ExtensionSettings = {
   buttons: {

--- a/src/core/settings/index.ts
+++ b/src/core/settings/index.ts
@@ -14,8 +14,8 @@ export interface ExtensionSettings {
 }
 
 export const MIN_FILE_SIZE_MB = 1;
-export const MAX_FILE_SIZE_MB = 20;
-export const DEFAULT_MAX_FILE_SIZE_MB = 3;
+export const MAX_FILE_SIZE_MB = 150;
+export const DEFAULT_MAX_FILE_SIZE_MB = 5;
 
 export const DEFAULT_SETTINGS: ExtensionSettings = {
   buttons: {

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -9,6 +9,7 @@ import type { ToolbarButtonsSettings } from '@core/settings';
 import { DEFAULT_SETTINGS, type ExtensionSettings, getSettings, saveSettings } from '@core/settings';
 import type { ToolbarButtonsSectionElement } from './sections/toolbar-buttons-section';
 import type { DownloadModeSectionElement } from './sections/download-mode-section';
+import type { FileSizeSectionElement } from './sections/file-size-section';
 import '@core/ui';
 
 describe('mjf-options-page', () => {
@@ -31,7 +32,7 @@ describe('mjf-options-page', () => {
   describe('section components', () => {
     test('renders mjf-options-section wrappers', () => {
       const sections = optionsPageElement.shadowRoot?.querySelectorAll('mjf-options-section');
-      expect(sections?.length).toBe(2);
+      expect(sections?.length).toBe(3);
     });
 
     test('renders mjf-toolbar-buttons-section', () => {
@@ -41,6 +42,11 @@ describe('mjf-options-page', () => {
 
     test('renders mjf-download-mode-section', () => {
       const section = optionsPageElement.shadowRoot?.querySelector('mjf-download-mode-section');
+      expect(section).not.toBeNull();
+    });
+
+    test('renders mjf-file-size-section', () => {
+      const section = optionsPageElement.shadowRoot?.querySelector('mjf-file-size-section');
       expect(section).not.toBeNull();
     });
 
@@ -54,6 +60,12 @@ describe('mjf-options-page', () => {
       const section = optionsPageElement.shadowRoot
         ?.querySelector<DownloadModeSectionElement>('mjf-download-mode-section');
       expect(section?.mode).toBe(DEFAULT_SETTINGS.downloadMode);
+    });
+
+    test('passes maxFileSize to mjf-file-size-section', () => {
+      const section = optionsPageElement.shadowRoot
+        ?.querySelector<FileSizeSectionElement>('mjf-file-size-section');
+      expect(section?.maxFileSize).toBe(DEFAULT_SETTINGS.maxFileSize);
     });
 
     test('mjf-download-mode-section is not disabled when download button is on', () => {
@@ -104,6 +116,25 @@ describe('mjf-options-page', () => {
       test('saveSettings receives updated buttons', () => {
         const saved = (saveSettings as Mock<typeof saveSettings>).mock.calls[0][0] as ExtensionSettings;
         expect(saved.buttons).toEqual(updatedButtons);
+      });
+    });
+
+    describe('when file-size-change fires', () => {
+      beforeEach(async () => {
+        const section = optionsPageElement.shadowRoot?.querySelector('mjf-file-size-section');
+        section?.dispatchEvent(
+          new CustomEvent<number>('file-size-change', { detail: 8, bubbles: true }),
+        );
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
+
+      test('calls saveSettings once', () => {
+        expect(saveSettings).toHaveBeenCalledTimes(1);
+      });
+
+      test('saveSettings receives updated maxFileSize', () => {
+        const saved = (saveSettings as Mock<typeof saveSettings>).mock.calls[0][0] as ExtensionSettings;
+        expect(saved.maxFileSize).toBe(8);
       });
     });
 

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -10,6 +10,7 @@ import './options.scss';
 import './section';
 import './sections/toolbar-buttons-section';
 import './sections/download-mode-section';
+import './sections/file-size-section';
 import {
   DEFAULT_SETTINGS,
   getSettings,
@@ -133,6 +134,17 @@ export class OptionsPageElement extends LitElement {
 
         <div class="separator"></div>
 
+        <mjf-options-section>
+          <span slot="title">Maximum File Size</span>
+          <span slot="hint">Files larger than this limit will be formatted but not fully processed. Increase this value for large JSON files at the cost of higher memory usage.</span>
+          <mjf-file-size-section
+            .maxFileSize=${this.settings.maxFileSize}
+            @file-size-change=${this.onFileSizeChange}>
+          </mjf-file-size-section>
+        </mjf-options-section>
+
+        <div class="separator"></div>
+
         <div class="section">
           <h2>Query history data</h2>
           <mjf-rounded-button @click=${this.onClearClick}>
@@ -160,6 +172,12 @@ export class OptionsPageElement extends LitElement {
   private async onModeChange(event: Event) {
     const downloadMode = (event as CustomEvent<DownloadMode>).detail;
     this.settings = { ...this.settings, downloadMode };
+    await saveSettings(this.settings);
+  }
+
+  private async onFileSizeChange(event: Event) {
+    const maxFileSize = (event as CustomEvent<number>).detail;
+    this.settings = { ...this.settings, maxFileSize };
     await saveSettings(this.settings);
   }
 

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -19,6 +19,7 @@ import {
   type ExtensionSettings,
   type ToolbarButtonsSettings,
 } from '@core/settings';
+import { FileSizeChangeEvent } from './sections/file-size-section.ts';
 
 const columns: TableColumn[] = [
   { title: 'Domain', path: 'domain' },
@@ -175,9 +176,8 @@ export class OptionsPageElement extends LitElement {
     await saveSettings(this.settings);
   }
 
-  private async onFileSizeChange(event: Event) {
-    const maxFileSize = (event as CustomEvent<number>).detail;
-    this.settings = { ...this.settings, maxFileSize };
+  private async onFileSizeChange({ detail }: FileSizeChangeEvent) {
+    this.settings = { ...this.settings, maxFileSize: detail };
     await saveSettings(this.settings);
   }
 

--- a/src/options/sections/file-size-section.test.ts
+++ b/src/options/sections/file-size-section.test.ts
@@ -32,7 +32,7 @@ describe('mjf-file-size-section', () => {
     expect(Number(input?.step)).toBe(1);
   });
 
-  test('default maxFileSize is 3', () => {
+  test('default maxFileSize equals DEFAULT_MAX_FILE_SIZE_MB', () => {
     expect(element.maxFileSize).toBe(DEFAULT_MAX_FILE_SIZE_MB);
   });
 
@@ -68,18 +68,38 @@ describe('mjf-file-size-section', () => {
     });
   });
 
-  describe('when the range input changes', () => {
+  describe('while dragging (input event)', () => {
     let handler: Mock<(e: FileSizeChangeEvent) => void>;
-    let input: HTMLInputElement;
 
     beforeEach(async () => {
       handler = rstest.fn();
       element.addEventListener('file-size-change', handler as unknown as EventListener);
       const found = element.shadowRoot?.querySelector<HTMLInputElement>('input[type="range"]');
       if (!found) throw new Error('range input not found');
-      input = found;
-      input.value = '7';
-      input.dispatchEvent(new Event('input', { bubbles: true }));
+      found.value = '7';
+      found.dispatchEvent(new Event('input', { bubbles: true }));
+      await element.updateComplete;
+    });
+
+    test('updates the maxFileSize property for live label', () => {
+      expect(element.maxFileSize).toBe(7);
+    });
+
+    test('does not dispatch a file-size-change event', () => {
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the range input is committed (change event)', () => {
+    let handler: Mock<(e: FileSizeChangeEvent) => void>;
+
+    beforeEach(async () => {
+      handler = rstest.fn();
+      element.addEventListener('file-size-change', handler as unknown as EventListener);
+      const found = element.shadowRoot?.querySelector<HTMLInputElement>('input[type="range"]');
+      if (!found) throw new Error('range input not found');
+      found.value = '7';
+      found.dispatchEvent(new Event('change', { bubbles: true }));
       await element.updateComplete;
     });
 

--- a/src/options/sections/file-size-section.test.ts
+++ b/src/options/sections/file-size-section.test.ts
@@ -75,7 +75,9 @@ describe('mjf-file-size-section', () => {
     beforeEach(async () => {
       handler = rstest.fn();
       element.addEventListener('file-size-change', handler as unknown as EventListener);
-      input = element.shadowRoot?.querySelector<HTMLInputElement>('input[type="range"]')!;
+      const found = element.shadowRoot?.querySelector<HTMLInputElement>('input[type="range"]');
+      if (!found) throw new Error('range input not found');
+      input = found;
       input.value = '7';
       input.dispatchEvent(new Event('input', { bubbles: true }));
       await element.updateComplete;

--- a/src/options/sections/file-size-section.test.ts
+++ b/src/options/sections/file-size-section.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, rstest, test, type Mock } from '@rstest/core';
+import { FileSizeChangeEvent, FileSizeSectionElement } from './file-size-section';
+import { defaultLitAsserts, renderLitElement } from '@testing/lit';
+import { DEFAULT_MAX_FILE_SIZE_MB, MAX_FILE_SIZE_MB, MIN_FILE_SIZE_MB } from '@core/settings';
+
+describe('mjf-file-size-section', () => {
+  let element: FileSizeSectionElement;
+
+  renderLitElement('mjf-file-size-section', el => {
+    element = el;
+  });
+
+  defaultLitAsserts(FileSizeSectionElement, () => element);
+
+  test('renders a range input', () => {
+    const input = element.shadowRoot?.querySelector<HTMLInputElement>('input[type="range"]');
+    expect(input).not.toBeNull();
+  });
+
+  test('range input has correct min attribute', () => {
+    const input = element.shadowRoot?.querySelector<HTMLInputElement>('input[type="range"]');
+    expect(Number(input?.min)).toBe(MIN_FILE_SIZE_MB);
+  });
+
+  test('range input has correct max attribute', () => {
+    const input = element.shadowRoot?.querySelector<HTMLInputElement>('input[type="range"]');
+    expect(Number(input?.max)).toBe(MAX_FILE_SIZE_MB);
+  });
+
+  test('range input has step of 1', () => {
+    const input = element.shadowRoot?.querySelector<HTMLInputElement>('input[type="range"]');
+    expect(Number(input?.step)).toBe(1);
+  });
+
+  test('default maxFileSize is 3', () => {
+    expect(element.maxFileSize).toBe(DEFAULT_MAX_FILE_SIZE_MB);
+  });
+
+  test('value label shows current value in MB', () => {
+    const label = element.shadowRoot?.querySelector('.value-label');
+    expect(label?.textContent?.trim()).toBe(`${element.maxFileSize} MB`);
+  });
+
+  test('renders min bound label', () => {
+    const bounds = element.shadowRoot?.querySelectorAll('.bounds span');
+    expect(bounds?.[0]?.textContent?.trim()).toBe(`${MIN_FILE_SIZE_MB} MB`);
+  });
+
+  test('renders max bound label', () => {
+    const bounds = element.shadowRoot?.querySelectorAll('.bounds span');
+    expect(bounds?.[1]?.textContent?.trim()).toBe(`${MAX_FILE_SIZE_MB} MB`);
+  });
+
+  describe('when maxFileSize property changes', () => {
+    beforeEach(async () => {
+      element.maxFileSize = 10;
+      await element.updateComplete;
+    });
+
+    test('updates the value label', () => {
+      const label = element.shadowRoot?.querySelector('.value-label');
+      expect(label?.textContent?.trim()).toBe('10 MB');
+    });
+
+    test('reflects the value on the range input', () => {
+      const input = element.shadowRoot?.querySelector<HTMLInputElement>('input[type="range"]');
+      expect(Number(input?.value)).toBe(10);
+    });
+  });
+
+  describe('when the range input changes', () => {
+    let handler: Mock<(e: FileSizeChangeEvent) => void>;
+    let input: HTMLInputElement;
+
+    beforeEach(async () => {
+      handler = rstest.fn();
+      element.addEventListener('file-size-change', handler as unknown as EventListener);
+      input = element.shadowRoot?.querySelector<HTMLInputElement>('input[type="range"]')!;
+      input.value = '7';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      await element.updateComplete;
+    });
+
+    test('dispatches a file-size-change event', () => {
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    test('event detail contains the new value as a number', () => {
+      const detail = (handler.mock.calls[0][0] as FileSizeChangeEvent).detail;
+      expect(detail).toBe(7);
+    });
+
+    test('updates the maxFileSize property', () => {
+      expect(element.maxFileSize).toBe(7);
+    });
+  });
+});

--- a/src/options/sections/file-size-section.ts
+++ b/src/options/sections/file-size-section.ts
@@ -58,7 +58,7 @@ export class FileSizeSectionElement extends LitElement {
     `,
   ];
 
-  @property({ type: Number })
+  @property({ type: Number, attribute: 'max-file-size' })
   public maxFileSize = 3;
 
   public override render() {

--- a/src/options/sections/file-size-section.ts
+++ b/src/options/sections/file-size-section.ts
@@ -1,0 +1,92 @@
+import { css, html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { boxingFixCss } from '@core/styles/lit';
+import { optionsSectionStyles } from '../section';
+import { MAX_FILE_SIZE_MB, MIN_FILE_SIZE_MB } from '@core/settings';
+
+export class FileSizeChangeEvent extends CustomEvent<number> {
+  constructor(value: number) {
+    super('file-size-change', { detail: value, bubbles: true, composed: true });
+  }
+}
+
+declare global {
+  interface HTMLElementEventMap {
+    'file-size-change': FileSizeChangeEvent;
+  }
+
+  interface HTMLElementTagNameMap {
+    'mjf-file-size-section': FileSizeSectionElement;
+  }
+}
+
+@customElement('mjf-file-size-section')
+export class FileSizeSectionElement extends LitElement {
+  public static override readonly styles = [
+    boxingFixCss,
+    optionsSectionStyles,
+    css`
+      .range-wrapper {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .range-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      input[type='range'] {
+        flex: 1;
+        cursor: pointer;
+      }
+
+      .value-label {
+        min-width: 48px;
+        text-align: right;
+        font-weight: 600;
+      }
+
+      .bounds {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.8em;
+        opacity: 0.6;
+      }
+    `,
+  ];
+
+  @property({ type: Number })
+  public maxFileSize = 3;
+
+  public override render() {
+    return html`
+      <div class="range-wrapper">
+        <div class="range-row">
+          <input
+            type="range"
+            min=${MIN_FILE_SIZE_MB}
+            max=${MAX_FILE_SIZE_MB}
+            step="1"
+            .value=${String(this.maxFileSize)}
+            @input=${this.onRangeInput}
+          />
+          <span class="value-label">${this.maxFileSize} MB</span>
+        </div>
+        <div class="bounds">
+          <span>${MIN_FILE_SIZE_MB} MB</span>
+          <span>${MAX_FILE_SIZE_MB} MB</span>
+        </div>
+      </div>
+    `;
+  }
+
+  private onRangeInput(event: Event) {
+    const target = event.target as HTMLInputElement;
+    const value = Number(target.value);
+    this.maxFileSize = value;
+    this.dispatchEvent(new FileSizeChangeEvent(value));
+  }
+}

--- a/src/options/sections/file-size-section.ts
+++ b/src/options/sections/file-size-section.ts
@@ -2,7 +2,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { boxingFixCss } from '@core/styles/lit';
 import { optionsSectionStyles } from '../section';
-import { MAX_FILE_SIZE_MB, MIN_FILE_SIZE_MB } from '@core/settings';
+import { DEFAULT_MAX_FILE_SIZE_MB, MAX_FILE_SIZE_MB, MIN_FILE_SIZE_MB } from '@core/settings';
 
 export class FileSizeChangeEvent extends CustomEvent<number> {
   constructor(value: number) {
@@ -59,7 +59,7 @@ export class FileSizeSectionElement extends LitElement {
   ];
 
   @property({ type: Number, attribute: 'max-file-size' })
-  public maxFileSize = 3;
+  public maxFileSize = DEFAULT_MAX_FILE_SIZE_MB;
 
   public override render() {
     return html`
@@ -71,7 +71,8 @@ export class FileSizeSectionElement extends LitElement {
             max=${MAX_FILE_SIZE_MB}
             step="1"
             .value=${String(this.maxFileSize)}
-            @input=${this.onRangeInput}
+            @input=${this.onRangeLiveUpdate}
+            @change=${this.onRangeCommit}
           />
           <span class="value-label">${this.maxFileSize} MB</span>
         </div>
@@ -83,7 +84,12 @@ export class FileSizeSectionElement extends LitElement {
     `;
   }
 
-  private onRangeInput(event: Event) {
+  private onRangeLiveUpdate(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.maxFileSize = Number(target.value);
+  }
+
+  private onRangeCommit(event: Event) {
     const target = event.target as HTMLInputElement;
     const value = Number(target.value);
     this.maxFileSize = value;

--- a/testing/settings.mock.ts
+++ b/testing/settings.mock.ts
@@ -1,5 +1,5 @@
 import { rstest } from '@rstest/core';
-import type { ExtensionSettings } from '@core/settings';
+import { type ExtensionSettings } from '@core/settings';
 
 const defaultSettings: ExtensionSettings = {
   buttons: {
@@ -9,7 +9,7 @@ const defaultSettings: ExtensionSettings = {
     download: true,
   },
   downloadMode: 'dropdown',
-  maxFileSize: 3,
+  maxFileSize: 10,
 };
 
 rstest.mock('@core/settings', () => ({

--- a/testing/settings.mock.ts
+++ b/testing/settings.mock.ts
@@ -9,6 +9,7 @@ const defaultSettings: ExtensionSettings = {
     download: true,
   },
   downloadMode: 'dropdown',
+  maxFileSize: 3,
 };
 
 rstest.mock('@core/settings', () => ({


### PR DESCRIPTION
## Summary

- Adds a `maxFileSize` field (in MB) to `ExtensionSettings` with a default of 3 MB and a 1–20 MB range
- New `mjf-file-size-section` Lit component renders an `input[type=range]` in the Options page with a live value label and bound labels
- The content script now reads `maxFileSize` from settings and computes the byte limit dynamically instead of using the hardcoded 3 MB constant
- Warning message shown to the user reflects the actual configured limit

## Test plan

- [ ] All 731 existing tests pass (`yarn test`)
- [ ] New `mjf-file-size-section` component tests cover: rendering, min/max/step attributes, default value, label updates, property binding, event dispatch (`file-size-change`)
- [ ] `extension.test.ts` covers: content within a custom limit is tokenized normally (not formatted)
- [ ] `options.test.ts` covers: new section is rendered, `maxFileSize` is passed in, `file-size-change` is persisted via `saveSettings`
- [ ] Production build succeeds (`yarn build:production`)
- [ ] Open the Options page and verify the range slider appears between "Download Button Mode" and "Query history data"
- [ ] Change the slider and reload a JSON page larger than the previous limit to confirm the new threshold is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)