### PR TITLE
feat: support file:// protocol for local JSON files

### DIFF
--- a/plugins/rsbuild-v3-manifest-plugin/plugin.ts
+++ b/plugins/rsbuild-v3-manifest-plugin/plugin.ts
@@ -85,7 +85,7 @@ export const manifestGeneratorPlugin = (options?: ManifestGeneratorParams): Rsbu
         content_scripts: [
           ...baseManifest.content_scripts ?? [],
           {
-            matches: ['<all_urls>'],
+            matches: ['<all_urls>', 'file://*/*'],
             js: [contentScript],
             run_at: 'document_start',
           },

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
         host_permissions: [
           '*://*/*',
           '<all_urls>',
+          'file://*/*',
         ],
         content_security_policy: {
           extension_pages: 'script-src \'self\' \'wasm-unsafe-eval\'; object-src \'self\';',

--- a/src/content-script/extension.ts
+++ b/src/content-script/extension.ts
@@ -3,7 +3,7 @@ import { createElement } from '@core/dom';
 import { registerStyle } from '@core/ui/helpers';
 import { isNotNull } from 'typed-assert';
 import { buildDom } from './dom';
-import { extractFileName, isErrorNode } from './helpers';
+import { extractDomainKey, extractFileName, isErrorNode } from './helpers';
 import { findNodeWithCode } from './json-detector';
 import { type TabChangedEvent } from './ui/toolbox/toolbox';
 import { type ErrorNodeElement } from './ui/error-node';
@@ -99,7 +99,7 @@ export const runExtension = async () => {
       try {
         const info = await jq(preNode.innerText, query);
         container.setQueryContent(prepareResponse(info));
-        await pushHistory(globalThis.location.hostname, query);
+        await pushHistory(extractDomainKey(globalThis.location.href), query);
       } catch (error: unknown) {
         if (isErrorNode(error)) {
           if (error.scope === 'jq') {

--- a/src/content-script/helpers.test.ts
+++ b/src/content-script/helpers.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from '@rstest/core';
+import { extractDomainKey, extractFileName } from './helpers';
+
+describe('extractFileName', () => {
+  const cases = [
+    { url: null, expected: 'data' },
+    { url: undefined, expected: 'data' },
+    { url: '', expected: 'data' },
+    { url: 'https://example.com/api/data.json', expected: 'data' },
+    { url: 'https://example.com/api/response', expected: 'response' },
+    { url: 'https://example.com/', expected: 'example-com' },
+    { url: 'https://api.example.com/v1/users', expected: 'users' },
+    { url: 'https://example.com/data.json?foo=bar', expected: 'data' },
+    { url: 'file:///Users/user/data.json', expected: 'data' },
+    { url: 'file:///Users/user/response', expected: 'response' },
+    { url: 'file:///data.json', expected: 'data' },
+    { url: 'file:///path/to/my-file.json', expected: 'my-file' },
+  ];
+
+  test.each(cases)('$url → $expected', ({ url, expected }) => {
+    expect(extractFileName(url)).toBe(expected);
+  });
+});
+
+describe('extractDomainKey', () => {
+  const cases = [
+    { url: null, expected: '' },
+    { url: undefined, expected: '' },
+    { url: '', expected: '' },
+    { url: 'https://example.com/api/data.json', expected: 'example.com' },
+    { url: 'https://api.example.com/v1/users', expected: 'api.example.com' },
+    { url: 'http://localhost:3000/data.json', expected: 'localhost' },
+    { url: 'file:///Users/user/data.json', expected: '/Users/user/data.json' },
+    { url: 'file:///data.json', expected: '/data.json' },
+    { url: 'file:///path/to/my-file.json', expected: '/path/to/my-file.json' },
+    { url: 'file:///C:/Users/user/data.json', expected: '/C:/Users/user/data.json' },
+  ];
+
+  test.each(cases)('$url → $expected', ({ url, expected }) => {
+    expect(extractDomainKey(url)).toBe(expected);
+  });
+});

--- a/src/content-script/helpers.ts
+++ b/src/content-script/helpers.ts
@@ -33,3 +33,13 @@ export const extractFileName = (url: string | undefined | null): string => {
 
   return lastSection || hostname.replaceAll('.', '-');
 };
+
+export const extractDomainKey = (url: string | undefined | null): string => {
+  if (!url) {
+    return '';
+  }
+
+  const { hostname, pathname, protocol } = new URL(url);
+
+  return protocol === 'file:' ? pathname : hostname;
+};

--- a/src/content-script/ui/query-input/query-input.ts
+++ b/src/content-script/ui/query-input/query-input.ts
@@ -2,7 +2,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { isRedoEvent, isSubmitEvent, isUndoEvent, isWrapEvent } from './query-input.helpers';
-import { throws } from '../../helpers';
+import { extractDomainKey, throws } from '../../helpers';
 import { HistoryManager } from './history-manager';
 import { resource } from '@core/browser';
 import { AutocompleteController } from './autocomplete.controller';
@@ -101,7 +101,7 @@ export class QueryInputElement extends LitElement {
   public error: string | null = null;
 
   private readonly historyManager = new HistoryManager<HistoryItem>();
-  private readonly autocomplete = new AutocompleteController(this, globalThis.location.hostname);
+  private readonly autocomplete = new AutocompleteController(this, extractDomainKey(globalThis.location.href));
 
   private readonly inputRef = createRef<HTMLInputElement>();
 


### PR DESCRIPTION
## Summary

- Add `file://*/*` to manifest `host_permissions` and `content_scripts.matches` — Chrome requires the explicit pattern alongside `<all_urls>` to inject into `file://` pages
- Fix JQ query history key: for `file://` URLs `hostname` is `''`, so `extractDomainKey` returns `pathname` instead (giving each local file its own isolated history)
- Add `extractDomainKey` helper with test coverage; also add `extractFileName` tests for `file://` URLs

> **Note for users**: "Allow access to file URLs" must be enabled for the extension in `chrome://extensions`.

## Test plan

- [x] All existing tests pass (`yarn test`)
- [x] `extractFileName` and `extractDomainKey` covered for `file://` URL cases
- [x] Production build succeeds (`yarn build:production`)
- [x] Manually open a local `.json` file via `file://` — extension formats it
- [ ] JQ query history is saved/retrieved per file path, not collapsed under empty hostname

🤖 Generated with [Claude Code](https://claude.com/claude-code)