### PR TITLE
feat: add md5, sha256, sha512 as native jq functions

### DIFF
--- a/src/faq/content/content.ts
+++ b/src/faq/content/content.ts
@@ -34,6 +34,7 @@ export class ContentElement extends LitElement {
       <mjf-section .content=${lang.en.builtinOperatorsAndFunctions}></mjf-section>
       <mjf-section .content=${lang.en.conditionalsAndComparisons}></mjf-section>
       <mjf-section .content=${lang.en.regularExpressions}></mjf-section>
+      <mjf-section .content=${lang.en.hashing}></mjf-section>
       <mjf-section .content=${lang.en.advancedFeatures}></mjf-section>
       <mjf-section .content=${lang.en.math}></mjf-section>
       <mjf-section .content=${lang.en.assignment}></mjf-section>

--- a/src/faq/sections/en/hashing.md
+++ b/src/faq/sections/en/hashing.md
@@ -1,0 +1,31 @@
+## Hashing
+
+Modern JSON Formatter extends jq with built-in cryptographic hash functions. These functions take a **string** input and
+return the lowercase hexadecimal digest. Passing a non-string value (e.g. a number or object) raises an error.
+
+### `md5`
+
+Computes the **MD5** hash of a string and outputs its 32-character lowercase hex digest.
+
+> **Note:** MD5 is not cryptographically secure. Use it only for checksums or non-security-critical fingerprinting.
+
+#### Examples:
+<mjf-example-table query="md5" input='"hello"' output='"5d41402abc4b2a76b9719d911017c592"'></mjf-example-table>
+<mjf-example-table query=".token | md5" input='{"token": "secret"}' output='"5ebe2294ecd0e0f08eab7690d2a6ee69"'></mjf-example-table>
+<mjf-example-table query="map(md5)" input='["foo", "bar"]' output='["acbd18db4cc2f85cedef654fccc4a4d8","37b51d194a7513e45b56f6524f2d51f2"]'></mjf-example-table>
+
+### `sha256`
+
+Computes the **SHA-256** hash of a string and outputs its 64-character lowercase hex digest.
+
+#### Examples:
+<mjf-example-table query="sha256" input='"hello"' output='"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"'></mjf-example-table>
+<mjf-example-table query=".password | sha256" input='{"password": "hunter2"}' output='"f52fbd32b2b3b86ff88ef6c490628285f482af15ddcb29541f94bcf526a3f6c7"'></mjf-example-table>
+
+### `sha512`
+
+Computes the **SHA-512** hash of a string and outputs its 128-character lowercase hex digest.
+
+#### Examples:
+<mjf-example-table query="sha512" input='"hello"' output='"9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043"'></mjf-example-table>
+<mjf-example-table query=".data | sha512" input='{"data": "hello world"}' output='"309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f"'></mjf-example-table>

--- a/src/faq/sections/en/index.ts
+++ b/src/faq/sections/en/index.ts
@@ -4,6 +4,7 @@ import assignment from './assignment.md';
 import basicFilters from './basic-filters.md';
 import builtinOperatorsAndFunctions from './builtin-operators-and-functions.md';
 import conditionalsAndComparisons from './conditionals-and-comparisons.md';
+import hashing from './hashing.md';
 import intro from './intro.md';
 import math from './math.md';
 import regularExpressions from './regular-expressions.md';
@@ -19,4 +20,5 @@ export default {
   advancedFeatures,
   math,
   assignment,
+  hashing,
 } satisfies FaqSection;

--- a/src/faq/sections/models.ts
+++ b/src/faq/sections/models.ts
@@ -8,4 +8,5 @@ export interface FaqSection {
   advancedFeatures: MarkdownFile;
   math: MarkdownFile;
   assignment: MarkdownFile;
+  hashing: MarkdownFile;
 }

--- a/src/worker.test.ts
+++ b/src/worker.test.ts
@@ -40,6 +40,33 @@ describe('worker-wasm', () => {
         query: '.foo',
         expected: tNull(),
       },
+      {
+        name: 'md5 hash',
+        input: `
+          "test"
+        `,
+        query: 'md5',
+        expected: tString('098f6bcd4621d373cade4e832627b4f6'),
+      },
+      {
+        name: 'sha256 hash',
+        input: `
+          "test"
+        `,
+        query: 'sha256',
+        expected: tString('9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08'),
+      },
+      {
+        name: 'sha512 hash',
+        input: `
+          "test"
+        `,
+        query: 'sha512',
+        expected: tString(
+          'ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac'
+          + '185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff',
+        ),
+      },
     ];
 
     test.each(testCases)('$name', ({ input, query: jq, expected }) => {

--- a/worker-wasm/core/Cargo.toml
+++ b/worker-wasm/core/Cargo.toml
@@ -8,3 +8,5 @@ jaq-json = { version = "2.0.0" }
 jaq-core = "3.0.0"
 jaq-std = "3.0.0"
 hifijson = "0.5.0"
+md5 = "0.7"
+sha2 = "0.10"

--- a/worker-wasm/core/src/hash.rs
+++ b/worker-wasm/core/src/hash.rs
@@ -1,0 +1,92 @@
+use jaq_core::native::{bome, run, Filter, Fun, v};
+use jaq_core::{Cv, DataT, RunPtr};
+use jaq_std::ValT;
+use sha2::Digest as _;
+
+pub fn hash_funs<D: DataT>() -> impl Iterator<Item = Fun<D>>
+where
+    for<'a> D::V<'a>: ValT,
+{
+    hash_run::<D>().into_vec().into_iter().map(run)
+}
+
+fn hash_run<D: DataT>() -> Box<[Filter<RunPtr<D>>]>
+where
+    for<'a> D::V<'a>: ValT,
+{
+    Box::new([
+        ("md5", v(0), |cv: Cv<'_, D>| {
+            bome(cv.1.try_as_utf8_bytes().map(|bytes| {
+                format!("{:x}", md5::compute(bytes)).into()
+            }))
+        }),
+        ("sha256", v(0), |cv: Cv<'_, D>| {
+            bome(cv.1.try_as_utf8_bytes().map(|bytes| {
+                encode_hex(&sha2::Sha256::digest(bytes)).into()
+            }))
+        }),
+        ("sha512", v(0), |cv: Cv<'_, D>| {
+            bome(cv.1.try_as_utf8_bytes().map(|bytes| {
+                encode_hex(&sha2::Sha512::digest(bytes)).into()
+            }))
+        }),
+    ])
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    bytes.iter().fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
+        use std::fmt::Write as _;
+        write!(s, "{b:02x}").unwrap();
+        s
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::node::Node;
+    use crate::node_json_factory::NodeJsonFactory;
+    use crate::parser::{parse_json, Factory};
+    use crate::query::query_json;
+
+    fn node(json: &str) -> Node {
+        parse_json(json.as_bytes(), NodeJsonFactory).unwrap()
+    }
+
+    fn expect(output: &str) -> Node {
+        NodeJsonFactory.tuple(vec![node(output)])
+    }
+
+    #[test]
+    fn md5_of_string() {
+        let result = query_json("\"hello\"", "md5").unwrap();
+        assert_eq!(result, expect("\"5d41402abc4b2a76b9719d911017c592\""));
+    }
+
+    #[test]
+    fn sha256_of_string() {
+        let result = query_json("\"hello\"", "sha256").unwrap();
+        assert_eq!(
+            result,
+            expect("\"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\"")
+        );
+    }
+
+    #[test]
+    fn sha512_of_string() {
+        let result = query_json("\"hello\"", "sha512").unwrap();
+        assert_eq!(
+            result,
+            expect("\"9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043\"")
+        );
+    }
+
+    #[test]
+    fn md5_on_non_string_returns_error() {
+        let result = query_json("42", "md5");
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "cannot use 42 as string"
+        );
+    }
+}

--- a/worker-wasm/core/src/hash.rs
+++ b/worker-wasm/core/src/hash.rs
@@ -1,7 +1,8 @@
 use jaq_core::native::{bome, run, Filter, Fun, v};
 use jaq_core::{Cv, DataT, RunPtr};
 use jaq_std::ValT;
-use sha2::Digest as _;
+use sha2::Digest;
+use std::fmt::Write;
 
 pub fn hash_funs<D: DataT>() -> impl Iterator<Item = Fun<D>>
 where
@@ -34,10 +35,9 @@ where
 }
 
 fn encode_hex(bytes: &[u8]) -> String {
-    bytes.iter().fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
-        use std::fmt::Write as _;
-        write!(s, "{b:02x}").unwrap();
-        s
+    bytes.iter().fold(String::with_capacity(bytes.len() * 2), |mut string, b| {
+        write!(string, "{b:02x}").unwrap();
+        string
     })
 }
 

--- a/worker-wasm/core/src/lib.rs
+++ b/worker-wasm/core/src/lib.rs
@@ -1,5 +1,6 @@
 mod convert;
 mod format;
+mod hash;
 mod jaq_json_factory;
 mod minify;
 mod node;

--- a/worker-wasm/core/src/query.rs
+++ b/worker-wasm/core/src/query.rs
@@ -1,4 +1,5 @@
 use crate::convert::val_to_node;
+use crate::hash::hash_funs;
 use crate::node::Node;
 use crate::node_json_factory::NodeJsonFactory;
 use jaq_core::{data, load, unwrap_valr, Compiler, Ctx, Vars};
@@ -48,18 +49,27 @@ pub fn query_json(json: &str, query: &str) -> Result<Node, Box<dyn Error>> {
         path: (),
     };
 
-    let loader = Loader::new(jaq_core::defs().chain(jaq_std::defs()).chain(jaq_json::defs()));
-    let arena = Arena::default();
+    let defs = jaq_core::defs()
+        .chain(jaq_std::defs())
+        .chain(jaq_json::defs());
 
-    let modules = loader
-        .load(&arena, program)
+    let funs = jaq_core::funs::<data::JustLut<Val>>()
+        .chain(jaq_std::funs::<data::JustLut<Val>>())
+        .chain(jaq_json::funs::<data::JustLut<Val>>())
+        .chain(hash_funs::<data::JustLut<Val>>());
+
+    let arena = &Arena::default();
+
+    let modules = Loader::new(defs)
+        .load(arena, program)
         .map_err(|errors| {
             let messages: Vec<String> = errors.iter().map(|(_, e)| format_load_error(e)).collect();
             Box::<dyn Error>::from(messages.join("; "))
         })?;
 
+
     let filter: jaq_core::Filter<data::JustLut<Val>> = Compiler::default()
-        .with_funs(jaq_core::funs::<data::JustLut<Val>>().chain(jaq_std::funs::<data::JustLut<Val>>()).chain(jaq_json::funs::<data::JustLut<Val>>()))
+        .with_funs(funs)
         .compile(modules)
         .map_err(|errors| {
             let messages: Vec<String> = errors


### PR DESCRIPTION
## Summary

- Adds `md5`, `sha256`, and `sha512` as native filter functions in the WASM/jaq core, usable in any JQ query expression (e.g. `"hello" | md5`, `.token | sha256`)
- Implemented in a new `hash.rs` module using `md5 v0.7` and `sha2 v0.10` crates; registered alongside the standard jaq function set
- Passing a non-string value returns a descriptive type error (e.g. `cannot use 42 as string`)
- Adds unit tests in Rust (`hash.rs`) and integration tests in TypeScript (`worker.test.ts`)

## Test plan

- [ ] `cargo test --manifest-path worker-wasm/core/Cargo.toml` — all Rust unit tests pass
- [ ] `yarn test` — TypeScript integration tests for md5/sha256/sha512 pass
- [ ] Manual: open the extension, enter a JSON string, run `md5` / `sha256` / `sha512` in the query bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)